### PR TITLE
feat: add falcor router

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "test": "tape -r babel-register src/**/*spec.js | faucet"
+    "test": "tape -r babel-polyfill -r babel-register src/**/*spec.js | faucet"
   },
   "repository": {
     "type": "git",
@@ -29,9 +29,13 @@
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.5.2",
     "body-parser": "^1.15.0",
-    "express": "^4.13.4"
+    "express": "^4.13.4",
+    "falcor-express": "^0.1.2",
+    "falcor-http-datasource": "^0.1.3",
+    "falcor-router": "^0.2.12"
   },
   "devDependencies": {
+    "babel-polyfill": "^6.5.0",
     "faucet": "0.0.1",
     "nodemon": "^1.8.1",
     "tape": "^4.4.0"

--- a/src/falcor/index.js
+++ b/src/falcor/index.js
@@ -1,0 +1,9 @@
+import Router from 'falcor-router';
+import falcorExpress from 'falcor-express';
+import worlds from './worlds';
+
+export default falcorExpress.dataSourceRoute( ( req, res ) => new Router(
+  []
+    .concat( worlds( req, res ) )
+));
+

--- a/src/falcor/worlds/index.js
+++ b/src/falcor/worlds/index.js
@@ -1,0 +1,35 @@
+export const getWorldProps = ( ids, fields ) => new Promise( resolve => {
+  /**
+   * An array of paths and their values we'll send over the wire.
+   */
+  let paths = [];
+
+  /**
+   * A mock world to use
+   */
+  const testWorld = {
+    name: 'Sesame Street',
+    msg: 'Hello, world!',
+  };
+
+  /**
+   * Iterate through each requested World ID...
+   */
+  ids.forEach( id => {
+    /**
+     * And add to `paths` the path/value pairs for each requested field.
+     */
+    paths = paths.concat( fields.map( field => {
+      return { path: [ 'worldsById', id, field ], value: testWorld[ field ] };
+    }));
+  });
+
+  resolve( paths );
+});
+
+export default ( req, res ) => [
+  {
+    route: 'worldsById[{integers:ids}]["name", "msg"]',
+    get: pathSet => getWorldProps( pathSet.ids, pathSet[ 2 ] ),
+  },
+];

--- a/src/falcor/worlds/spec.js
+++ b/src/falcor/worlds/spec.js
@@ -1,0 +1,84 @@
+import test from 'tape';
+import { getWorldProps } from './';
+
+test( 'getWorldProps with 1 id and 1 field', async t => {
+  let actual, expected, promise;
+
+  t.plan( 2 );
+
+  promise = getWorldProps( [ 1 ], [ 'name' ] );
+  actual = typeof promise.then;
+  expected = 'function';
+  t.equals( actual, expected, 'should return a promise' );
+
+  expected = [
+    { path: [ 'worldsById', 1, 'name' ], value: 'Sesame Street' },
+  ];
+  actual = await promise;
+  t.deepEquals( actual, expected, 'should output correct path' );
+
+  t.end();
+});
+
+test( 'getWorldProps with 1 id and 2 field', async t => {
+  let actual, expected, promise;
+
+  t.plan( 2 );
+
+  promise = getWorldProps( [ 1 ], [ 'name', 'msg' ] );
+  actual = typeof promise.then;
+  expected = 'function';
+  t.equals( actual, expected, 'should return a promise' );
+
+  expected = [
+    { path: [ 'worldsById', 1, 'name' ], value: 'Sesame Street' },
+    { path: [ 'worldsById', 1, 'msg' ], value: 'Hello, world!' },
+  ];
+  actual = await promise;
+  t.deepEquals( actual, expected, 'should output correct path' );
+
+  t.end();
+});
+
+test( 'getWorldProps with 2 ids and 1 field', async t => {
+  let actual, expected, promise;
+
+  t.plan( 2 );
+
+  promise = getWorldProps( [ 1, 2 ], [ 'name' ] );
+  actual = typeof promise.then;
+  expected = 'function';
+  t.equals( actual, expected, 'should return a promise' );
+
+  expected = [
+    { path: [ 'worldsById', 1, 'name' ], value: 'Sesame Street' },
+    { path: [ 'worldsById', 2, 'name' ], value: 'Sesame Street' },
+  ];
+  actual = await promise;
+  t.deepEquals( actual, expected, 'should output correct path' );
+
+  t.end();
+});
+
+test( 'getWorldProps with 2 ids and 2 field', async t => {
+  let actual, expected, promise;
+
+  t.plan( 2 );
+
+  promise = getWorldProps( [ 1, 2 ], [ 'name', 'msg' ] );
+  actual = typeof promise.then;
+  expected = 'function';
+  t.equals( actual, expected, 'should return a promise' );
+
+  expected = [
+    { path: [ 'worldsById', 1, 'name' ], value: 'Sesame Street' },
+    { path: [ 'worldsById', 1, 'msg' ], value: 'Hello, world!' },
+    { path: [ 'worldsById', 2, 'name' ], value: 'Sesame Street' },
+    { path: [ 'worldsById', 2, 'msg' ], value: 'Hello, world!' },
+  ];
+  actual = await promise;
+  t.deepEquals( actual, expected, 'should output correct path' );
+
+  t.end();
+});
+

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,13 @@
 import express from 'express';
 import bodyParser from 'body-parser';
+import falcorRouter from './falcor';
 import api from './api';
 
 const app = express();
 
 app.use( bodyParser.json() );
 app.use( '/api', api );
+app.use( '/model.json', falcorRouter );
 
 app.get( '/*', function ( req, res ) {
   res.status( 404 ).json({


### PR DESCRIPTION
- add falcor router with test `worldsById` path
- expose the router as `/model.json`
