### PR TITLE
feat(outlines): generate scrivener-friendly opml

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "jsonwebtoken": "^5.7.0",
     "mongodb": "^2.1.7",
     "multiparty": "^4.1.2",
-    "oppuml": "0.0.2",
     "shortid": "^2.2.4",
+    "opml-generator": "^1.1.1",
     "uservoice-sso": "^0.1.0"
   },
   "devDependencies": {

--- a/src/falcor/characters/index.js
+++ b/src/falcor/characters/index.js
@@ -10,6 +10,7 @@ import {
   setProps,
   fuzzyFind,
   getRandom,
+  withLastAndLength,
 } from './../transforms';
 
 export default ( db, req, res ) => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import cors from 'cors';
 import api from './api';
+import conf from './config';
 
 const app = express();
 
@@ -19,8 +20,7 @@ app.get( '/*', function ( req, res ) {
   });
 });
 
-const port = 9999;
-app.listen( port, function () {
-  console.log( `Listening on port ${port}...` )
+app.listen( conf.server.port, function () {
+  console.log( `Listening on port ${conf.server.port}...` )
 });
 


### PR DESCRIPTION
Not thrilled about the way I pulled in the opml-generator package, but could not find another way because of the way the package `module.exports = function`.

The OMPL generation code itself may benefit from a refactor, but it works. I can save the output as a .opml file, then import into Scrivener with results matching expectations.
