### PR TITLE
feat: add neo4j to the database configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/StoryShop/api#readme",
   "dependencies": {
-    "@reactivex/rxjs": "^5.0.0-beta.2",
+    "@reactivex/rxjs": "^5.0.0-beta.12",
     "aws-sdk": "^2.2.41",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
@@ -49,6 +49,7 @@
     "jsonwebtoken": "^5.7.0",
     "mongodb": "2.1.15",
     "multiparty": "^4.1.2",
+    "neo4j-driver": "^1.0.4",
     "opml-generator": "^1.1.1",
     "shortid": "^2.2.4",
     "uservoice-sso": "^0.1.0"

--- a/src/api/auth/find-or-create-user.js
+++ b/src/api/auth/find-or-create-user.js
@@ -2,7 +2,7 @@ import { Observable } from 'rx';
 import { generateId } from '../../utils';
 
 export default ( database, email, givenName, familyName, displayName ) => {
-  let db = database.map( db => db.collection( 'users' ) );
+  let db = database.map( db => db.mongo.collection( 'users' ) );
 
   return db
     .flatMap( db => db.findOne({

--- a/src/api/auth/find-user.js
+++ b/src/api/auth/find-user.js
@@ -1,7 +1,7 @@
 import { Observable } from 'rx';
 
 export default ( database, _id ) => {
-  let db = database.map( db => db.collection( 'users' ) );
+  let db = database.map( db => db.mongo.collection( 'users' ) );
 
   return db.flatMap( db => db.findOne({ _id }));
 };

--- a/src/api/upload.js
+++ b/src/api/upload.js
@@ -58,7 +58,7 @@ export default ( db ) => {
         };
 
         db
-          .map( db => db.collection( 'users' ) )
+          .map( db => db.mongo.collection( 'users' ) )
           .flatMap( db => db.findOneAndUpdate(
             { _id: req.user._id },
             { $push: { files: upload }, $inc: { filesLength: 1 } },

--- a/src/falcor/elements/index.js
+++ b/src/falcor/elements/index.js
@@ -124,7 +124,6 @@ export default ( db, req, res ) => {
             })
             ;
         })
-        .catch(e=>console.log("err",e.stack))
         ,
     },
   ];

--- a/src/falcor/transforms/elements.js
+++ b/src/falcor/transforms/elements.js
@@ -7,7 +7,7 @@ import {
 } from '../../utils';
 
 export const getElementsForWorld = ( world, indices ) => db => {
-  return Observable.fromPromise( db.collection( 'elements' ).find({ world_id: world._id }).toArray() )
+  return Observable.fromPromise( db.mongo.collection( 'elements' ).find({ world_id: world._id }).toArray() )
     .flatMap( elements => indices.map( idx => ({
       _id: world._id,
       idx,
@@ -17,7 +17,7 @@ export const getElementsForWorld = ( world, indices ) => db => {
 };
 
 // export const getElements = ( ids, user ) => db => {
-//   return Observable.fromPromise( db.collection( 'elements' ).find({ _id: { $in: ids }, $or: [
+//   return Observable.fromPromise( db.mongo.collection( 'elements' ).find({ _id: { $in: ids }, $or: [
 //       { owners: { $eq: user._id } },
 //       { writers: { $eq: user._id } },
 //       { readers: { $eq: user._id } },
@@ -27,7 +27,7 @@ export const getElementsForWorld = ( world, indices ) => db => {
 // };
 
 export const getElementCount = world => db => {
-  return Observable.fromPromise( db.collection( 'elements' ).count({ world_id: world._id }) )
+  return Observable.fromPromise( db.mongo.collection( 'elements' ).count({ world_id: world._id }) )
   .map( elements => ({ _id: world._id, elements }) )
   ;
 };

--- a/src/falcor/transforms/worlds.js
+++ b/src/falcor/transforms/worlds.js
@@ -20,7 +20,7 @@ export function getWorlds ( ids, user ) {
   }
 
   return this.flatMap( db => {
-    return Observable.fromPromise( db.collection( 'worlds' ).find( query ).toArray() )
+    return Observable.fromPromise( db.mongo.collection( 'worlds' ).find( query ).toArray() )
     .selectMany( w => w )
     ;
   });
@@ -35,7 +35,7 @@ export function setWorldProps ( propsById, user ) {
           { writers: { $eq: user._id } },
         ];
 
-        return db.collection( 'worlds' ).findOneAndUpdate( { _id, $or }, { $set: propsById[ _id ] }, {
+        return db.mongo.collection( 'worlds' ).findOneAndUpdate( { _id, $or }, { $set: propsById[ _id ] }, {
           returnOriginal: false,
         });
       })

--- a/src/falcor/users/index.js
+++ b/src/falcor/users/index.js
@@ -27,7 +27,7 @@ import UserVoiceSSO from 'uservoice-sso';
 // })));
 
 export const setLastVisited = ( user, ids ) => db =>
-  keysO( ids ).filter( id => id === user._id ).flatMap( id => db.collection( 'users' ).findOneAndUpdate(
+  keysO( ids ).filter( id => id === user._id ).flatMap( id => db.mongo.collection( 'users' ).findOneAndUpdate(
     { _id: id },
     { $set: { 'ux.lastVisited': ids[ id ].ux.lastVisited } },
     { returnOriginal: false }
@@ -36,7 +36,7 @@ export const setLastVisited = ( user, ids ) => db =>
   ;
 
 export const getLastVisited = ( user, ids ) => db =>
-  Observable.fromPromise( db.collection( 'users' ).find( { _id: { $in: ids, $eq: user._id } } ).toArray() )
+  Observable.fromPromise( db.mongo.collection( 'users' ).find( { _id: { $in: ids, $eq: user._id } } ).toArray() )
   .selectMany( docs => docs )
   .map( ({ _id, ux }) => ({ _id, ...ux }) )
   ;
@@ -130,7 +130,7 @@ export default ( db, req, res ) => {
     {
       route: 'usersById[{keys:ids}].files.length',
       get: pathSet => db
-        .flatMap( db => db.collection( 'users' ).find( { _id: { $in: pathSet.ids, $eq: user._id } } ).toArray() )
+        .flatMap( db => db.mongo.collection( 'users' ).find( { _id: { $in: pathSet.ids, $eq: user._id } } ).toArray() )
         .selectMany( d => d )
         .map( ({ _id, ...user }) => ({ _id, length: user.files ? user.files.length : 0 }) )
         ::toPathValues( ( i, f ) => [ 'usersById', i._id, 'files', f ], 'length' )
@@ -138,7 +138,7 @@ export default ( db, req, res ) => {
     {
       route: 'usersById[{keys:ids}].files[{integers:indices}]["name", "url", "contentType", "size", "extension"]',
       get: pathSet => db
-        .flatMap( db => db.collection( 'users' ).find( { _id: { $in: pathSet.ids, $eq: user._id } } ).toArray() )
+        .flatMap( db => db.mongo.collection( 'users' ).find( { _id: { $in: pathSet.ids, $eq: user._id } } ).toArray() )
         .selectMany( d => d )
         .flatMap( getWithinArray( 'files', pathSet.indices ) )
         .map( ({ files, ...o }) => ({ ...o, ...pathSet[ 4 ].reduce( ( o, k ) => { o[k] = files[k]; return o }, {} ) }) )

--- a/src/falcor/worlds/index.js
+++ b/src/falcor/worlds/index.js
@@ -56,7 +56,7 @@ export default ( db, req, res ) => {
       get: pathSet => Observable.from( pathSet.ids )
         .flatMap( _id => {
           return db
-            .map( db => db.collection( 'elements' ) )
+            .map( db => db.mongo.collection( 'elements' ) )
             .flatMap( db => db.distinct( 'tags', {
               world_id: { $in: pathSet.ids },
               $or: [


### PR DESCRIPTION
The database object is no longer a MongoDB connection. It is an object
with two keys: `mongo`, which points to the MongoDB connection; and
`neo`, which points to a wrapper around the Neo4j API.

Closes #24

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/storyshop/api/42)

<!-- Reviewable:end -->
